### PR TITLE
Fix for scalar conversion errors; closes #8

### DIFF
--- a/npytypes/quaternion/numpy_quaternion.c
+++ b/npytypes/quaternion/numpy_quaternion.c
@@ -338,8 +338,8 @@ TYPE ## _to_quaternion(type *ip, quaternion *op, npy_intp n,                   \
     }                                                                          \
 }
 
-MAKE_T_TO_QUATERNION(FLOAT, npy_uint32);
-MAKE_T_TO_QUATERNION(DOUBLE, npy_uint64);
+MAKE_T_TO_QUATERNION(FLOAT, npy_float);
+MAKE_T_TO_QUATERNION(DOUBLE, npy_double);
 MAKE_T_TO_QUATERNION(LONGDOUBLE, npy_longdouble);
 MAKE_T_TO_QUATERNION(BOOL, npy_bool);
 MAKE_T_TO_QUATERNION(BYTE, npy_byte);
@@ -366,8 +366,8 @@ TYPE ## _to_quaternion(type *ip, quaternion *op, npy_intp n,                   \
     }                                                                          \
 }
 
-MAKE_CT_TO_QUATERNION(CFLOAT, npy_uint32);
-MAKE_CT_TO_QUATERNION(CDOUBLE, npy_uint64);
+MAKE_CT_TO_QUATERNION(CFLOAT, npy_float);
+MAKE_CT_TO_QUATERNION(CDOUBLE, npy_double);
 MAKE_CT_TO_QUATERNION(CLONGDOUBLE, npy_longdouble);
 
 static void register_cast_function(int sourceType, int destType, PyArray_VectorUnaryFunc *castfunc)


### PR DESCRIPTION
This is just a couple minor typo fixes related to what @mcflan [suggested in Martin Ling's original work](https://github.com/martinling/numpy_quaternion/pull/9/files).  I have verified that they resolve the problems I reported in issue #8.
